### PR TITLE
added support for custom highlight groups and resizing sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ calling open() when sidebar is already open will cause it to refresh the list it
 
 
 ### Refresh Sidebar Directly
-you can refresh the sidebar directyly with
+you can refresh the sidebar directly with
 ```lua
-lua require("todo-sidebar.sidebar").refresh_buffer_items()
+lua require("todo-sidebar.sidebar").refresh_list()
 ```
 if the sidebar is not open it will just return out
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ return {
 
                     --     scroll_down     = "<C-d>",
                     --     scroll_up       = "<C-k>",
+
+                    --     decrease_width = "<",
+                    --     increase_width = ">",
                     -- },
                 }
             })

--- a/README.md
+++ b/README.md
@@ -77,8 +77,20 @@ return {
                 sidebar = {
                     -- git_cmd = "git",
 
-                    -- custom keyword list and case sensitivity
-                    -- keywords = { "TODO", "FIXME", "NOTE", "REVIEW" },
+                    -- custom keyword list
+                    -- keywords = {
+                    --     -- keyword to match and highlight group to use
+                    --     -- hl_group is optional, will default to hl_group="Comment"
+                    --     { keyword="TODO", hl_group="Todo" },
+                    --     { keyword="FIXME", hl_group="WarningMsg" },
+                    --     { keyword="NOTE", hl_group="Comment" },
+                    --     -- { keyword="NO_HL_GROUP" },
+
+                    --     -- can also just do string, same thing will do hl_group="Comment"
+                    --     -- "NO_TABLE"
+                    -- },
+
+                    -- keyword case sensitivity
                     -- case_sensitive = false,
 
                     -- max number of results in sidebar

--- a/lua/todo-sidebar/config.lua
+++ b/lua/todo-sidebar/config.lua
@@ -3,21 +3,20 @@ local M = {}
 function M.get_default_config()
 	return {
 		sidebar = {
-			keywords = { "TODO", "FIXME", "NOTE", },
+			keywords = {
+                { keyword="TODO", hl_group="Todo" },
+                { keyword="FIXME", hl_group="WarningMsg" },
+                { keyword="NOTE", hl_group="Comment" },
+            },
 			case_sensitive = false,
 
 			ignore_patterns = {
 				".git/",
 			},
 
-			git_tracked_only = true,
-
 			max_results = 500,
-			search_strategy = "git_grep",
-
 			git_cmd = "git",
 
-			git_grep_args = {},
 			width = 40,
 
 			position = "right",

--- a/lua/todo-sidebar/config.lua
+++ b/lua/todo-sidebar/config.lua
@@ -34,6 +34,9 @@ function M.get_default_config()
 
 				scroll_down = "<C-d>",
 				scroll_up = "<C-k>",
+
+                decrease_width = "<",
+                increase_width = ">",
 			},
 		},
 	}

--- a/lua/todo-sidebar/scanner.lua
+++ b/lua/todo-sidebar/scanner.lua
@@ -20,9 +20,15 @@ function M.find_todos_git_grep(sidebar, repo_root, callback)
 		return
 	end
 	local patterns = {}
-	for _, kw in ipairs(current_config.keywords) do
-		table.insert(patterns, "\\b" .. kw .. "\\b")
+
+	for _, kw_pair in ipairs(current_config.keywords) do
+		if type(kw_pair) == "table" then
+			table.insert(patterns, "\\b" .. kw_pair.keyword .. "\\b")
+		elseif type(kw_pair) == "string" then
+			table.insert(patterns, "\\b" .. kw_pair.. "\\b")
+		end
 	end
+
 	local grep_pattern = table.concat(patterns, "|")
 
 	local git_cmd = current_config.git_cmd
@@ -46,22 +52,31 @@ function M.find_todos_git_grep(sidebar, repo_root, callback)
 			for _, line in ipairs(output_lines) do
 				-- parse git grep output <filepath>:<line_number>:<text>
 				local file_rel, lnum, text = line:match("([^:]+):(%d+):(.*)")
-                local loc = -1
+				local loc = -1
 				if file_rel and lnum and text then
 					local matched = ""
 					local search_for_kw = current_config.case_sensitive and text or text:lower()
-					for _, kw_candidate in ipairs(current_config.keywords) do
-						local kw = current_config.case_sensitive and kw_candidate or kw_candidate:lower()
-                        loc = search_for_kw:find(kw, 1, true)
-                        print(loc)
-						if search_for_kw:find(kw, 1, true) then
-							matched = kw_candidate
-							break
+					for _, kw_pair in ipairs(current_config.keywords) do
+						local kw
+						if type(kw_pair) == "table" then
+							kw = current_config.case_sensitive and kw_pair.keyword or kw_pair.keyword:lower()
+							loc = search_for_kw:find(kw, 1, true)
+							if search_for_kw:find(kw, 1, true) then
+								matched = kw_pair.keyword
+								break
+							end
+						elseif type(kw_pair) == "string" then
+							kw = current_config.case_sensitive and kw_pair or kw_pair:lower()
+							loc = search_for_kw:find(kw, 1, true)
+							if search_for_kw:find(kw, 1, true) then
+								matched = kw_pair
+								break
+							end
 						end
 					end
 
-                    -- remove up to and past keyword matched
-                    local trimmed_text = text:sub(loc + #matched)
+					-- remove up to and past keyword matched
+					local trimmed_text = text:sub(loc + #matched)
 					-- remove leading white space
 					trimmed_text = trimmed_text:gsub("^%s*", "")
 

--- a/lua/todo-sidebar/sidebar.lua
+++ b/lua/todo-sidebar/sidebar.lua
@@ -201,6 +201,9 @@ function TodoSideBarUI:setup_mappings()
 
 	vim.keymap.set("n", km.scroll_down, "<C-d>", map_opts)
 	vim.keymap.set("n", km.scroll_up, "<C-u>", map_opts)
+
+    vim.keymap.set("n", km.decrease_width, "10<C-w><", map_opts)
+    vim.keymap.set("n", km.increase_width, "10<C-w>>", map_opts)
 end
 
 ---create the window and buffer for sidebar

--- a/lua/todo-sidebar/utils.lua
+++ b/lua/todo-sidebar/utils.lua
@@ -1,4 +1,5 @@
 local Path = require("plenary.path")
+local Filetype = require("plenary.filetype")
 
 local M = {}
 

--- a/lua/todo-sidebar/utils.lua
+++ b/lua/todo-sidebar/utils.lua
@@ -1,5 +1,4 @@
 local Path = require("plenary.path")
-local Filetype = require("plenary.filetype")
 
 local M = {}
 


### PR DESCRIPTION
let users define built in highlight groups in their setup

EX:
```lua
{ keyword="TODO", hl_group="Todo" },
{ keyword="FIXME", hl_group="WarningMsg" },
{ keyword="NOTE", hl_group="Comment" },
{ keyword="NO_HL_GROUP" }, -- hl_group is optional, will default to hl_group="Comment"
"NO_TABLE" -- can also just do string, same thing will do hl_group="Comment"
```

had to change a lot of lua/todo-sidebar/scanner.lua to support the highlight groups being defined in user config, will need to add ability for user custom highlight groups

also allow resizing with
```lua
decrease_width = "<",
increase_width = ">",

-- maps in sidebar.lua to
-- increase and decrease with by 10 characters
vim.keymap.set("n", km.decrease_width, "10<C-w><", map_opts)
vim.keymap.set("n", km.increase_width, "10<C-w>>", map_opts)
```